### PR TITLE
fix: Ignore if file does not exist

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,15 +20,18 @@ export default function ignore(options: FlatGitignoreOptions = {}): FlatConfigIt
   const files = Array.isArray(_files) ? _files : [_files]
 
   for (const file of files) {
-    const content = fs.readFileSync(file, 'utf8')
-    const parsed = parse(content)
-    const globs = parsed.globs()
-    for (const glob of globs) {
-      if (glob.type === 'ignore')
-        ignores.push(...glob.patterns)
-      else if (glob.type === 'unignore')
-        ignores.push(...glob.patterns.map((pattern: string) => `!${pattern}`))
+    try {
+      const content = fs.readFileSync(file, 'utf8')
+      const parsed = parse(content)
+      const globs = parsed.globs()
+      for (const glob of globs) {
+        if (glob.type === 'ignore')
+          ignores.push(...glob.patterns)
+        else if (glob.type === 'unignore')
+          ignores.push(...glob.patterns.map((pattern: string) => `!${pattern}`))
+      }
     }
+    catch (error) {}
   }
 
   return {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When the ignore file does not exist, an error will be reported when using eslint.

```
Error: ENOENT: no such file or directory, open '.gitignore'
    at Object.openSync (node:fs:603:3)
    at Object.readFileSync (node:fs:471:35)
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
