### PR TITLE
fix: when there is only one line of content in `.gitignore`, it may be misjudged as a file path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export default function ignore(options: FlatGitignoreOptions = {}): FlatConfigIt
         throw error
       continue
     }
-    const parsed = parse(content)
+    const parsed = parse(`${content}\n`)
     const globs = parsed.globs()
     for (const glob of globs) {
       if (glob.type === 'ignore')


### PR DESCRIPTION
fixed: #4