### PR TITLE
fix: inline `findUpSync` util for CJS compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "eslint": "^9.5.0"
   },
   "dependencies": {
-    "@eslint/compat": "^1.2.4",
-    "find-up-simple": "^1.0.0"
+    "@eslint/compat": "^1.2.4"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^3.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@eslint/compat':
         specifier: ^1.2.4
         version: 1.2.4(eslint@9.17.0(jiti@2.4.2))
-      find-up-simple:
-        specifier: ^1.0.0
-        version: 1.0.0
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^3.12.2

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { convertIgnorePatternToMinimatch } from '@eslint/compat'
-import { findUpSync } from 'find-up-simple'
 
 export interface FlatGitignoreOptions {
   /**
@@ -127,4 +126,24 @@ function relativeMinimatch(pattern: string, relativePath: string, cwd: string) {
 
   // otherwise it doesn't matches the current folder
   return null
+}
+
+function findUpSync(name: string, { cwd = process.cwd() } = {}) {
+  let directory = path.resolve(cwd)
+  const { root } = path.parse(directory)
+
+  while (directory && directory !== root) {
+    const filePath = path.isAbsolute(name) ? name : path.join(directory, name)
+
+    try {
+      const stats = fs.statSync(filePath)
+
+      if (stats.isFile()) {
+        return filePath
+      }
+    }
+    catch {}
+
+    directory = path.dirname(directory)
+  }
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR solves https://github.com/antfu/eslint-config-flat-gitignore/issues/16 by inlining simplified `findUpSync` util that was previously imported from `find-up-simple` (https://github.com/sindresorhus/find-up-simple/blob/main/index.js#L32). This caused issues because `eslint-config-flat-gitignore` was unusable in CJS environment because `find-up-simple` package is ESM-only.

Nice side effect is that there is only one external dependency now.

### Linked Issues

Closes https://github.com/antfu/eslint-config-flat-gitignore/issues/16
