### PR TITLE
fix: allow uncle files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,10 +130,6 @@ function relativeMinimatch(pattern: string, relativePath: string, cwd: string) {
   if (!isParent)
     return `${negated}${relativePath}${cleanPattern}`
 
-  // uncle directories don't make sense
-  if (!relativePath.match(/^(\.\.\/)+$/))
-    throw new Error('The ignore file location should be either a parent or child directory')
-
   // if it has ** depth it may be left as is
   if (cleanPattern.startsWith('**'))
     return pattern

--- a/test/system-with-uncle-gitignore.test.ts
+++ b/test/system-with-uncle-gitignore.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import ignore from '../src/index'
+
+describe('should execute tests in test/system-with-uncle-gitignore', () => {
+  process.chdir('test/system-with-uncle-gitignore/workspace')
+
+  it('allows referencing files which are neither descendents nor ancestors', () => {
+    expect(ignore({ files: ['../configs/.gitignore_global'] }))
+      .toMatchInlineSnapshot(`
+        {
+          "ignores": [
+            "**/globalignore",
+          ],
+          "name": "gitignore",
+        }
+      `)
+  })
+})

--- a/test/system-with-uncle-gitignore/configs/.gitignore_global
+++ b/test/system-with-uncle-gitignore/configs/.gitignore_global
@@ -1,0 +1,1 @@
+globalignore


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
There's currently a limitation which disallows `files` which are neither ancestors nor descendants of the cwd. Such a file is deemed an "uncle" in a code comment, though "cousin" may be a bit more accurate.

I _believe_ this restriction was added because the ignored paths in a cousin file will be resolved relative to the cwd and may produce nonsense paths. However, if the ignored paths have no beginning or middle slashes, they're effectively global ignores and can be resolved relative to anything. This is exactly the case described in #18 where I try to include my global gitignore.

### Linked Issues
Fixes #18

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
